### PR TITLE
feat: トピック単位での複数問題・解答管理機能を実装

### DIFF
--- a/src/components/LearningDetail.tsx
+++ b/src/components/LearningDetail.tsx
@@ -34,6 +34,10 @@ import {
   Cancel as CancelIcon,
   Visibility as VisibilityIcon,
   VisibilityOff as VisibilityOffIcon,
+  Add as AddIcon,
+  Remove as RemoveIcon,
+  ArrowForward as ArrowForwardIcon,
+  ArrowBack,
 } from "@mui/icons-material";
 import {
   doc,
@@ -49,9 +53,15 @@ import { db } from "../firebase";
 import { useNavigate, useParams } from "react-router-dom";
 import LoadingSpinner from "./LoadingSpinner";
 
+interface QAPair {
+  question: string;
+  answer: string;
+}
+
 interface LearningData {
   topic: string;
-  content: string;
+  content?: string;
+  qaPairs?: QAPair[];
   createdAt: Date;
   reviewDate?: Date;
   relatedLearnings?: string[];
@@ -73,12 +83,14 @@ const LearningDetail: React.FC = () => {
     LearningListItem[]
   >([]);
   const [contentVisible, setContentVisible] = useState(false);
+  const [currentQAIndex, setCurrentQAIndex] = useState(0);
   const [reviewInterval, setReviewInterval] = useState<string>("");
   const [studyComplete, setStudyComplete] = useState(false);
 
   // Edit form states
   const [editTopic, setEditTopic] = useState("");
   const [editContent, setEditContent] = useState("");
+  const [editQaPairs, setEditQaPairs] = useState<QAPair[]>([{ question: "", answer: "" }]);
   const [editRelatedLearnings, setEditRelatedLearnings] = useState<string[]>(
     []
   );
@@ -142,7 +154,8 @@ const LearningDetail: React.FC = () => {
 
         setLearning(learningData);
         setEditTopic(learningData.topic);
-        setEditContent(learningData.content);
+        setEditContent(learningData.content || "");
+        setEditQaPairs(learningData.qaPairs && learningData.qaPairs.length > 0 ? learningData.qaPairs : [{ question: "", answer: "" }]);
         setEditRelatedLearnings(learningData.relatedLearnings || []);
 
         // Fetch available learnings for related learnings
@@ -191,26 +204,40 @@ const LearningDetail: React.FC = () => {
     if (!learning) return;
     setIsEditing(false);
     setEditTopic(learning.topic);
-    setEditContent(learning.content);
+    setEditContent(learning.content || "");
+    setEditQaPairs(learning.qaPairs && learning.qaPairs.length > 0 ? learning.qaPairs : [{ question: "", answer: "" }]);
     setEditRelatedLearnings(learning.relatedLearnings || []);
   };
 
   const handleEditSave = async () => {
-    if (!id || !editTopic.trim() || !editContent.trim()) {
+    if (!id || !editTopic.trim()) {
       setAlert({
         open: true,
-        message: "トピックと学習内容の両方を入力してください。",
+        message: "トピックを入力してください。",
         severity: "error",
       });
       return;
     }
+
+    const hasValidQA = editQaPairs.some(pair => pair.question.trim() && pair.answer.trim());
+    if (!hasValidQA) {
+      setAlert({
+        open: true,
+        message: "少なくとも1つの問題と解答を入力してください。",
+        severity: "error",
+      });
+      return;
+    }
+
+    const validQaPairs = editQaPairs.filter(pair => pair.question.trim() && pair.answer.trim());
 
     setSaveLoading(true);
     try {
       const docRef = doc(db, "learnings", id);
       await updateDoc(docRef, {
         topic: editTopic.trim(),
-        content: editContent.trim(),
+        content: editContent.trim() || undefined,
+        qaPairs: validQaPairs,
         relatedLearnings: editRelatedLearnings,
       });
 
@@ -219,7 +246,8 @@ const LearningDetail: React.FC = () => {
           ? {
               ...prev,
               topic: editTopic.trim(),
-              content: editContent.trim(),
+              content: editContent.trim() || undefined,
+              qaPairs: validQaPairs,
               relatedLearnings: editRelatedLearnings,
             }
           : null
@@ -315,6 +343,36 @@ const LearningDetail: React.FC = () => {
 
   const handleCloseAlert = () => {
     setAlert({ ...alert, open: false });
+  };
+
+  const handleAddQAPair = () => {
+    setEditQaPairs([...editQaPairs, { question: "", answer: "" }]);
+  };
+
+  const handleRemoveQAPair = (index: number) => {
+    if (editQaPairs.length > 1) {
+      setEditQaPairs(editQaPairs.filter((_, i) => i !== index));
+    }
+  };
+
+  const handleQAPairChange = (index: number, field: 'question' | 'answer', value: string) => {
+    const newQaPairs = [...editQaPairs];
+    newQaPairs[index][field] = value;
+    setEditQaPairs(newQaPairs);
+  };
+
+  const handleNextQA = () => {
+    if (learning?.qaPairs && currentQAIndex < learning.qaPairs.length - 1) {
+      setCurrentQAIndex(currentQAIndex + 1);
+      setContentVisible(false);
+    }
+  };
+
+  const handlePrevQA = () => {
+    if (currentQAIndex > 0) {
+      setCurrentQAIndex(currentQAIndex - 1);
+      setContentVisible(false);
+    }
   };
 
   if (loading) {
@@ -416,19 +474,75 @@ const LearningDetail: React.FC = () => {
 
             <TextField
               fullWidth
-              label="学習内容"
+              label="補足メモ"
               variant="outlined"
               value={editContent}
               onChange={(e) => setEditContent(e.target.value)}
               margin="normal"
-              required
               multiline
-              minRows={8}
-              maxRows={20}
+              minRows={4}
+              maxRows={10}
               sx={{ mb: 3 }}
               slotProps={{ htmlInput: { maxLength: 3000 } }}
-              helperText={`${editContent.length}/3000文字`}
+              helperText={`${editContent.length}/3000文字（オプション）`}
             />
+
+            <Box sx={{ mb: 3 }}>
+              <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+                <Typography variant="h6">
+                  問題と解答
+                </Typography>
+                <Button
+                  variant="contained"
+                  size="small"
+                  startIcon={<AddIcon />}
+                  onClick={handleAddQAPair}
+                >
+                  問題を追加
+                </Button>
+              </Box>
+
+              {editQaPairs.map((pair, index) => (
+                <Box key={index} sx={{ mb: 3, p: 2, backgroundColor: "grey.50", borderRadius: 2 }}>
+                  <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 1 }}>
+                    <Typography variant="subtitle2">問題 {index + 1}</Typography>
+                    {editQaPairs.length > 1 && (
+                      <Button
+                        variant="outlined"
+                        size="small"
+                        color="error"
+                        startIcon={<RemoveIcon />}
+                        onClick={() => handleRemoveQAPair(index)}
+                      >
+                        削除
+                      </Button>
+                    )}
+                  </Box>
+                  <TextField
+                    fullWidth
+                    label="問題"
+                    value={pair.question}
+                    onChange={(e) => handleQAPairChange(index, 'question', e.target.value)}
+                    margin="normal"
+                    multiline
+                    minRows={2}
+                    slotProps={{ htmlInput: { maxLength: 1000 } }}
+                    helperText={`${pair.question.length}/1000文字`}
+                  />
+                  <TextField
+                    fullWidth
+                    label="解答"
+                    value={pair.answer}
+                    onChange={(e) => handleQAPairChange(index, 'answer', e.target.value)}
+                    margin="normal"
+                    multiline
+                    minRows={3}
+                    slotProps={{ htmlInput: { maxLength: 2000 } }}
+                    helperText={`${pair.answer.length}/2000文字`}
+                  />
+                </Box>
+              ))}
+            </Box>
 
             <Box sx={{ mb: 3 }}>
               <Typography
@@ -581,34 +695,15 @@ const LearningDetail: React.FC = () => {
               </Paper>
             </Box>
 
-            <Box sx={{ mb: 4 }}>
-              <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
-                <Typography variant="h6" sx={{ mr: 2, fontWeight: "bold" }}>
-                  学習内容:
+            {learning.content && (
+              <Box sx={{ mb: 4 }}>
+                <Typography variant="h6" sx={{ mb: 2, fontWeight: "bold" }}>
+                  補足メモ:
                 </Typography>
-                <Button
-                  variant="outlined"
-                  size="small"
-                  startIcon={
-                    contentVisible ? <VisibilityOffIcon /> : <VisibilityIcon />
-                  }
-                  onClick={() => setContentVisible(!contentVisible)}
-                  sx={{
-                    borderRadius: 2,
-                    px: 2,
-                    py: 0.5,
-                  }}
-                >
-                  {contentVisible ? "内容を隠す" : "内容を表示"}
-                </Button>
-              </Box>
-
-              {contentVisible && (
                 <Paper
                   variant="outlined"
                   sx={{
-                    p: 3,
-                    minHeight: "300px",
+                    p: 2,
                     backgroundColor: "grey.50",
                   }}
                 >
@@ -619,8 +714,107 @@ const LearningDetail: React.FC = () => {
                     {learning.content}
                   </Typography>
                 </Paper>
-              )}
-            </Box>
+              </Box>
+            )}
+
+            {learning.qaPairs && learning.qaPairs.length > 0 && (
+              <Box sx={{ mb: 4 }}>
+                <Box sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "space-between",
+                  mb: 2
+                }}>
+                  <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+                    問題 {currentQAIndex + 1} / {learning.qaPairs.length}
+                  </Typography>
+                  <Box sx={{ display: "flex", gap: 1 }}>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handlePrevQA}
+                      disabled={currentQAIndex === 0}
+                      startIcon={<ArrowBack />}
+                    >
+                      前へ
+                    </Button>
+                    <Button
+                      variant="outlined"
+                      size="small"
+                      onClick={handleNextQA}
+                      disabled={currentQAIndex === learning.qaPairs.length - 1}
+                      endIcon={<ArrowForwardIcon />}
+                    >
+                      次へ
+                    </Button>
+                  </Box>
+                </Box>
+
+                <Paper
+                  variant="outlined"
+                  sx={{
+                    p: 3,
+                    minHeight: "150px",
+                    backgroundColor: "white",
+                    mb: 2,
+                    border: "2px solid",
+                    borderColor: "primary.200"
+                  }}
+                >
+                  <Typography variant="subtitle2" sx={{ mb: 1, color: "grey.600", fontWeight: 600 }}>
+                    問題:
+                  </Typography>
+                  <Typography
+                    variant="body1"
+                    sx={{ whiteSpace: "pre-wrap", lineHeight: 1.8, fontWeight: 500 }}
+                  >
+                    {learning.qaPairs[currentQAIndex]?.question}
+                  </Typography>
+                </Paper>
+
+                <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
+                  <Typography variant="h6" sx={{ mr: 2, fontWeight: "bold", color: "success.dark" }}>
+                    解答:
+                  </Typography>
+                  <Button
+                    variant="outlined"
+                    size="small"
+                    color="success"
+                    startIcon={
+                      contentVisible ? <VisibilityOffIcon /> : <VisibilityIcon />
+                    }
+                    onClick={() => setContentVisible(!contentVisible)}
+                    sx={{
+                      borderRadius: 2,
+                      px: 2,
+                      py: 0.5,
+                    }}
+                  >
+                    {contentVisible ? "解答を隠す" : "解答を表示"}
+                  </Button>
+                </Box>
+
+                {contentVisible && (
+                  <Paper
+                    variant="outlined"
+                    sx={{
+                      p: 3,
+                      minHeight: "150px",
+                      backgroundColor: "success.50",
+                      border: "2px solid",
+                      borderColor: "success.200"
+                    }}
+                  >
+                    <Typography
+                      variant="body1"
+                      sx={{ whiteSpace: "pre-wrap", lineHeight: 1.8 }}
+                    >
+                      {learning.qaPairs[currentQAIndex]?.answer}
+                    </Typography>
+                  </Paper>
+                )}
+              </Box>
+            )}
 
             {learning.relatedLearnings &&
               learning.relatedLearnings.length > 0 && (

--- a/src/components/LearningList.tsx
+++ b/src/components/LearningList.tsx
@@ -74,9 +74,17 @@ const LearningList: React.FC = () => {
     });
   };
 
-  const getContentPreview = (content: string, maxLength: number = 100) => {
-    if (content.length <= maxLength) return content;
-    return content.substring(0, maxLength) + "...";
+  const getContentPreview = (learning: typeof learnings[0], maxLength: number = 100) => {
+    if (learning.qaPairs && learning.qaPairs.length > 0) {
+      const firstQuestion = learning.qaPairs[0].question;
+      if (firstQuestion.length <= maxLength) return `Q: ${firstQuestion}`;
+      return `Q: ${firstQuestion.substring(0, maxLength)}...`;
+    }
+    if (learning.content) {
+      if (learning.content.length <= maxLength) return learning.content;
+      return learning.content.substring(0, maxLength) + "...";
+    }
+    return "内容なし";
   };
 
   const filteredLearnings = learnings.filter((learning) => {
@@ -405,7 +413,7 @@ const LearningList: React.FC = () => {
                             flex: 1
                           }}
                         >
-                          {getContentPreview(learning.content, 120)}
+                          {getContentPreview(learning, 120)}
                         </Typography>
                         
                         <Box sx={{ 

--- a/src/store/slices/learningSlice.ts
+++ b/src/store/slices/learningSlice.ts
@@ -13,10 +13,16 @@ import {
 } from 'firebase/firestore';
 import { db } from '../../firebase';
 
+export interface QAPair {
+  question: string;
+  answer: string;
+}
+
 export interface LearningData {
   id: string;
   topic: string;
-  content: string;
+  content?: string;
+  qaPairs?: QAPair[];
   createdAt: Date;
   reviewDate?: Date;
   relatedLearnings?: string[];


### PR DESCRIPTION
- データモデルに QAPair インターフェースと qaPairs フィールドを追加
- LearningForm で複数Q&A入力UIを実装（追加・削除機能付き）
- 学習モードで問題と解答を順番に表示（前へ・次へボタン付き）
- LearningDetail で複数Q&A表示と編集機能を実装
- LearningList で最初の問題をプレビュー表示
- 既存の content フィールドは補足メモとして保持（後方互換性確保）